### PR TITLE
CRM-388 Error handling simulate credit steps

### DIFF
--- a/src/pages/prospect/components/SourceIncome/config.tsx
+++ b/src/pages/prospect/components/SourceIncome/config.tsx
@@ -1,4 +1,7 @@
 import { IncomeCard } from "@components/cards/IncomeCard";
+import { ICustomerData } from "@context/CustomerContext/types";
+
+import { IIncome } from "./types";
 
 interface IncomeProps {
   values: string[];
@@ -76,4 +79,14 @@ function MicroBusinesses({
   );
 }
 
-export { IncomeCapital, IncomeEmployment, MicroBusinesses };
+function getInitialValues(customerData: ICustomerData) {
+  return {
+    borrower_id: customerData?.publicCode ?? "",
+    borrower: customerData?.fullName ?? "",
+    capital: ["0", "0", "0"],
+    employment: ["0", "0", "0"],
+    businesses: ["0", "0"],
+  } as IIncome;
+}
+
+export { IncomeCapital, IncomeEmployment, MicroBusinesses, getInitialValues };

--- a/src/pages/prospect/components/SourceIncome/index.tsx
+++ b/src/pages/prospect/components/SourceIncome/index.tsx
@@ -13,7 +13,12 @@ import { IIncomeSources } from "@services/creditLimit/types";
 import { BaseModal } from "@components/modals/baseModal";
 import { ICustomerData } from "@context/CustomerContext/types";
 
-import { IncomeEmployment, IncomeCapital, MicroBusinesses } from "./config";
+import {
+  IncomeEmployment,
+  IncomeCapital,
+  MicroBusinesses,
+  getInitialValues,
+} from "./config";
 import { StyledContainer } from "./styles";
 import { dataReport } from "../TableObligationsFinancial/config";
 import { IIncome } from "./types";
@@ -36,7 +41,7 @@ export function SourceIncome(props: ISourceIncomeProps) {
     disabled,
     showEdit = true,
     data,
-    customerData,
+    customerData = {} as ICustomerData,
   } = props;
   const [isOpenModal, setIsOpenModal] = useState(false);
   const [isOpenEditModal, setIsOpenEditModal] = useState(false);
@@ -44,28 +49,38 @@ export function SourceIncome(props: ISourceIncomeProps) {
   const isMobile = useMediaQuery("(max-width:880px)");
   const [dataValues, setDataValues] = useState<IIncome | null>(null);
   useEffect(() => {
-    if (data) {
+    if (data && Object.keys(data).length > 0) {
+      const sourceData = data as IIncomeSources;
       const values: IIncome = {
         borrower_id: customerData?.publicCode ?? "",
         borrower: customerData?.fullName ?? "",
         capital: [
-          (data.FinancialIncome ?? 0).toString(),
-          (data.Dividends ?? 0).toString(),
-          (data.Leases ?? 0).toString(),
+          (sourceData.FinancialIncome ?? 0).toString(),
+          (sourceData.Dividends ?? 0).toString(),
+          (sourceData.Leases ?? 0).toString(),
         ],
         employment: [
-          (data.PeriodicSalary ?? 0).toString(),
-          (data.OtherNonSalaryEmoluments ?? 0).toString(),
-          (data.PensionAllowances ?? 0).toString(),
+          (sourceData.PeriodicSalary ?? 0).toString(),
+          (sourceData.OtherNonSalaryEmoluments ?? 0).toString(),
+          (sourceData.PensionAllowances ?? 0).toString(),
         ],
         businesses: [
-          (data.ProfessionalFees ?? 0).toString(),
-          (data.PersonalBusinessUtilities ?? 0).toString(),
+          (sourceData.ProfessionalFees ?? 0).toString(),
+          (sourceData.PersonalBusinessUtilities ?? 0).toString(),
         ],
       };
+
       setDataValues(values);
       setBorrowerIncome(values);
+
       initialValuesRef.current = values;
+    } else {
+      const defaultValues = getInitialValues(customerData);
+
+      setDataValues(defaultValues);
+      setBorrowerIncome(defaultValues);
+
+      initialValuesRef.current = defaultValues;
     }
   }, [data]);
 

--- a/src/pages/prospect/components/TableObligationsFinancial/interface.tsx
+++ b/src/pages/prospect/components/TableObligationsFinancial/interface.tsx
@@ -271,16 +271,6 @@ export const TableFinancialObligationsUI = ({
     </Tr>
   );
 
-  const renderNoDataRow = () => (
-    <Tr>
-      <Td colSpan={visibleHeaders.length} align="center" type="custom">
-        <Text size="large" type="label" appearance="gray" textAlign="center">
-          {dataReport.noData}
-        </Text>
-      </Td>
-    </Tr>
-  );
-
   const renderDataRows = () =>
     //eslint-disable-next-line @typescript-eslint/no-explicit-any
     paddedCurrentData.map((prop: any, rowIndex: number) => {
@@ -429,11 +419,31 @@ export const TableFinancialObligationsUI = ({
           <Tr>{renderHeaders()}</Tr>
         </Thead>
         <Tbody>
-          {loading
-            ? renderLoadingRow()
-            : extraDebtors.length === 0
-              ? renderNoDataRow()
-              : renderDataRows()}
+          {loading ? (
+            renderLoadingRow()
+          ) : extraDebtors.length === 0 ? (
+            <Tr border="left">
+              <Td colSpan={visibleHeaders.length} align="center" type="custom">
+                <Stack
+                  gap="16px"
+                  direction="column"
+                  height="250px"
+                  justifyContent="center"
+                >
+                  <Text
+                    size="large"
+                    type="label"
+                    appearance="gray"
+                    textAlign="center"
+                  >
+                    {dataReport.noData}
+                  </Text>
+                </Stack>
+              </Td>
+            </Tr>
+          ) : (
+            renderDataRows()
+          )}
         </Tbody>
         {!loading && dataInformation.length > 0 && (
           <Tfoot>

--- a/src/pages/simulateCredit/interface.tsx
+++ b/src/pages/simulateCredit/interface.tsx
@@ -464,6 +464,7 @@ export function SimulateCreditUI(props: SimulateCreditUIProps) {
                       isMobile={isMobile}
                       requestValue={requestValue}
                       setRequestValue={setRequestValue}
+                      obligationPayments={obligationPayments}
                     />
                   )}
                 {currentStepsNumber &&

--- a/src/pages/simulateCredit/steps/loanAmount/config.ts
+++ b/src/pages/simulateCredit/steps/loanAmount/config.ts
@@ -11,3 +11,9 @@ export const dataAmount = {
   creditText: "Cupo disponible sin garantía por línea de crédito",
   placeholderValue: "Valor que espera recibir",
 };
+
+export const dataModalDisableLoanAmount = {
+  title: "Información",
+  description: "El cliente no cuenta con obligaciones de cartera.",
+  understood: "Entendido",
+};

--- a/src/pages/simulateCredit/steps/loanAmount/index.tsx
+++ b/src/pages/simulateCredit/steps/loanAmount/index.tsx
@@ -1,6 +1,8 @@
 import { Formik, Field, Form } from "formik";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
+import { MdInfoOutline } from "react-icons/md";
+import { Icon } from "@inubekit/inubekit";
 import * as Yup from "yup";
 import { MdOutlineAttachMoney } from "react-icons/md";
 import {
@@ -22,8 +24,10 @@ import {
 } from "@mocks/add-prospect/payment-channel/paymentchannel.mock";
 import { get } from "@mocks/utils/dataMock.service";
 import { IPaymentChannel } from "@services/creditRequest/types";
+import { BaseModal } from "@components/modals/baseModal";
+import { IPayment } from "@services/creditLimit/getCreditPayments/types";
 
-import { dataAmount } from "./config";
+import { dataAmount, dataModalDisableLoanAmount } from "./config";
 
 export interface ILoanAmountProps {
   initialValues: {
@@ -40,6 +44,7 @@ export interface ILoanAmountProps {
   >;
   handleOnChange: (newData: Partial<ILoanAmountProps["initialValues"]>) => void;
   onFormValid: (isValid: boolean) => void;
+  obligationPayments: IPayment[] | undefined;
 }
 
 export function LoanAmount(props: ILoanAmountProps) {
@@ -50,6 +55,7 @@ export function LoanAmount(props: ILoanAmountProps) {
     onFormValid,
     requestValue,
     setRequestValue,
+    obligationPayments,
   } = props;
   const { id } = useParams();
   const loanId = parseInt(id || "0", 10);
@@ -59,6 +65,7 @@ export function LoanAmount(props: ILoanAmountProps) {
     dataAmount[
       loanText === "expectToReceive" ? "expectToReceive" : "amountRequested"
     ];
+  const [showInfoModal, setShowInfoModal] = useState(false);
 
   useEffect(() => {
     get("mockRequest_value")
@@ -78,6 +85,13 @@ export function LoanAmount(props: ILoanAmountProps) {
     periodicity: Yup.string(),
     payAmount: Yup.string(),
   });
+
+  const userHaveObligationPayments =
+    obligationPayments && obligationPayments.length > 0;
+
+  const handleCloseModalToggleState = () => {
+    setShowInfoModal(false);
+  };
 
   return (
     <Fieldset hasOverflow>
@@ -147,7 +161,21 @@ export function LoanAmount(props: ILoanAmountProps) {
                       handleOnChange({ toggleChecked: checked });
                     }}
                     checked={values.toggleChecked}
+                    disabled={!userHaveObligationPayments}
                   />
+                  {!userHaveObligationPayments && (
+                    <Stack margin="2px 0">
+                      <Icon
+                        icon={<MdInfoOutline />}
+                        appearance="primary"
+                        size="16px"
+                        onClick={() => {
+                          setShowInfoModal(true);
+                        }}
+                        cursorHover
+                      />
+                    </Stack>
+                  )}
                   <Text
                     type="label"
                     size="large"
@@ -239,6 +267,19 @@ export function LoanAmount(props: ILoanAmountProps) {
                 )}
               </Stack>
             </Stack>
+            {showInfoModal && (
+              <BaseModal
+                title={dataModalDisableLoanAmount.title}
+                nextButton={dataModalDisableLoanAmount.understood}
+                handleNext={handleCloseModalToggleState}
+                handleClose={handleCloseModalToggleState}
+                width={isMobile ? "280px" : "450px"}
+              >
+                <Stack>
+                  <Text>{dataModalDisableLoanAmount.description}</Text>
+                </Stack>
+              </BaseModal>
+            )}
           </Form>
         )}
       </Formik>

--- a/src/pages/simulateCredit/steps/loanAmount/index.tsx
+++ b/src/pages/simulateCredit/steps/loanAmount/index.tsx
@@ -25,7 +25,7 @@ import {
 import { get } from "@mocks/utils/dataMock.service";
 import { IPaymentChannel } from "@services/creditRequest/types";
 import { BaseModal } from "@components/modals/baseModal";
-import { IPayment } from "@services/creditLimit/getCreditPayments/types";
+import { IPayment } from "@services/portfolioObligation/SearchAllPortfolioObligationPayment/types";
 
 import { dataAmount, dataModalDisableLoanAmount } from "./config";
 


### PR DESCRIPTION
Was tested the steps: `Valor de la solicitud`, `Obligaciones financieras` and `Fuentes de ingreso` the lasts two their performance is correct when don't recive any data, they show the respectives labels and your layout show correctly. 

On the  `Valor de la solicitude ` step, was add the disable icon with a modal when the user don't have portfolio obligations, whit that is avoid the step  `Obligaciones recogidas` show it, when the system don't send data to this component.